### PR TITLE
BHD tags

### DIFF
--- a/auto_upload.py
+++ b/auto_upload.py
@@ -1261,11 +1261,22 @@ def choose_right_tracker_keys():
         # -!-!- Tags -!-!- #
         if optional_key == 'tags':
             # All we currently support regarding tags, is to assign the 'Scene' tag if we are uploading a scene release
+            upload_these_tags_list = []
             for tag in optional_value:
-                if str(tag).lower() in str(torrent_info.keys()).lower():
-                    tracker_settings[optional_key] = str(tag)
-                    break
 
+                # This will check for the 'Scene' tag
+                if str(tag).lower() in str(torrent_info.keys()).lower():
+                    upload_these_tags_list.append(str(tag))
+                    # tracker_settings[optional_key] = str(tag)
+
+                # This will check for webdl/webrip tag
+                if str(tag) in ["WEBRip", "WEBDL"]:
+                    # Check if we are uploading one of those ^^ 'sources'
+                    if str(tag).lower() == str(torrent_info["source_type"]).lower():
+                        upload_these_tags_list.append(str(tag))
+                        # tracker_settings[optional_key] = str(tag)
+
+            tracker_settings[optional_key] = ",".join(upload_these_tags_list)
 
 
 

--- a/images/upload_screenshots.py
+++ b/images/upload_screenshots.py
@@ -138,7 +138,7 @@ def take_upload_screens(duration, upload_media_import, torrent_title_import, bas
     # Verify that num_of_screenshots is not set to 0
     if num_of_screenshots == "0":
         with open(base_path + "/temp_upload/description.txt", "w") as no_images:
-            no_images.write("[center] \n---------------------- [size=22]Screenshots[/size] ----------------------\n[/center]")
+            no_images.write("[center] ---------------------- [size=22]Screenshots[/size] ----------------------\n[/center]")
             no_images.close()
         logging.error('num_of_screenshots is set to 0, continuing without screenshots')
         return "num_of_screenshots is set to 0, continuing without screenshots"
@@ -158,7 +158,7 @@ def take_upload_screens(duration, upload_media_import, torrent_title_import, bas
 
     if len(upload_to_host_dict) == 0:
         with open(base_path + "/temp_upload/description.txt", "w") as no_images:
-            no_images.write("[center] \n---------------------- [size=22]Screenshots[/size] ----------------------\n[/center]")
+            no_images.write("[center] ---------------------- [size=22]Screenshots[/size] ----------------------\n[/center]")
             no_images.close()
 
         logging.info("All image hosts are disabled by the user so we'll upload the torrent without screenshots")
@@ -178,7 +178,7 @@ def take_upload_screens(duration, upload_media_import, torrent_title_import, bas
     # As to not keep opening and closing description.txt we instead open it now, put in the header and then write in each images bbcode then finally close after the loop
     with open(base_path + "/temp_upload/description.txt", "w") as write_bbcode_description_txt:
         # write_bbcode_description_txt = open(base_path + "/temp_upload/description.txt", "w")
-        write_bbcode_description_txt.write("[center] \n ---------------------- [size=22]Screenshots[/size] ---------------------- \n")
+        write_bbcode_description_txt.write("[center] ---------------------- [size=22]Screenshots[/size] ---------------------- \n")
 
         # Now we start the actual upload process
         for host_site, host_api in upload_to_host_dict.items():

--- a/site_templates/asiancinema.json
+++ b/site_templates/asiancinema.json
@@ -5,6 +5,7 @@
   "torrents_search": "https://asiancinema.me/api/torrents/filter?api_token={api_key}",
   "source": "acm",
   "bbcode_line_break": "<br />",
+  "luv_uu": " ❤ ",
 
 
   "translation": {

--- a/site_templates/beyond-hd.json
+++ b/site_templates/beyond-hd.json
@@ -5,6 +5,8 @@
   "torrents_search": "https://beyond-hd.me/api/torrents/{api_key}",
   "source": "bhd",
   "bbcode_line_break": "[br][/br]",
+  "luv_uu": " [color=red]<3[/color] ",
+
 
   "translation": {
     "dot_torrent": "file",

--- a/site_templates/blutopia.json
+++ b/site_templates/blutopia.json
@@ -5,6 +5,7 @@
   "torrents_search": "https://blutopia.xyz/api/torrents/filter?api_token={api_key}",
   "source": "blu",
   "bbcode_line_break": "<br />",
+  "luv_uu": " ❤ ",
 
 
   "translation": {


### PR DESCRIPTION
This is a BHD specific update, We support a few "optional items" such as `edition` `region` `webdl` `webrip` `scene` As the name suggests these are not required but its nice to have. When assigning the required API keys we now run a small loop that tries to match any optional keys to info we have identified earlier 

If you upload this release
`servant.s02e09.1080p.web.h264-glhf.mkv`
the script will now assign the following optional tags on BHD `Scene` `WEB-DL`

I've also added support for Bluray regions but since Bluray discs are not currently supported... I can't test/use this feature yet